### PR TITLE
List of things as a property rather than links

### DIFF
--- a/proposals/td_for_tdir.md
+++ b/proposals/td_for_tdir.md
@@ -31,7 +31,9 @@ Example Thing Description for a directory:
         "type": "string"
       },
       "forms": [{
-        "href": "/properties/things"
+        "href": "/things",
+        "op": "readproperty",
+        "htv:methodName": "GET"
       }]
     }
   },
@@ -43,17 +45,18 @@ Example Thing Description for a directory:
         "type": "string"
       },
       "forms": [{
-        "href": "/actions/add_thing"
+        "href": "/things",
+        "op": "invokeaction",
+        "htv:methodName": "POST"
       }]
     },
     "removeThing": {
       "title": "Remove Device",
       "@type": "RemoveThingAction",
-      "input": {
-        "type": "string"
-      },
       "forms": [{
-        "href": "/actions/remove_thing"
+        "op": "invokeaction",
+        "href": "/things/{id}",
+        "htv:methodName": "DELETE"
       }]
     }
   },


### PR DESCRIPTION
Potential alternative solution where the list of things is a property of the directory, rather than enumerating them in the top level links section. This helps keep the Thing Description as more of a static resource.